### PR TITLE
Fix: TypeError: global.todos.findIdnex is not a function

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -68,7 +68,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: "Invalid todo ID" }, { status: 400 })
   }
 
-  const todoIndex = global.todos!.findIdnex((t) => t.id === idNum)
+  const todoIndex = global.todos!.findIndex((t) => t.id === idNum)
 
   if (todoIndex === -1) {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 })


### PR DESCRIPTION
## Error Description
The application encountered a TypeError because 'findIdnex' is not a valid method on the global.todos object. This likely indicates a typo in the method name; it should probably be 'findIndex'.

## Technical Details
Trace ID: ad5718c7b677ebeb57b18299480f9753

## Changes
This PR contains an automated fix for the production error identified in the telemetry data.

---
*Generated by Codex Runner Bot*