### PR TITLE
Fix: TypeError: global.todos.findIdnex is not a function

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -68,7 +68,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: "Invalid todo ID" }, { status: 400 })
   }
 
-  const todoIndex = global.todos!.findIdnex((t) => t.id === idNum)
+  const todoIndex = global.todos!.findIndex((t) => t.id === idNum)
 
   if (todoIndex === -1) {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 })


### PR DESCRIPTION
## Error Description
The application encountered a TypeError because it attempted to call `findIdnex` on `global.todos`, but this method does not exist. This likely indicates a typo in the method name. Check the implementation of `global.todos` and correct `findIdnex` to `findIndex` or another appropriate method.

## Technical Details
Trace ID: 040b70ac05c1156f1df13c3887e3e73f

## Changes
This PR contains an automated fix for the production error identified in the telemetry data.

---
*Generated by Codex Runner Bot*