### PR TITLE
Fix: TypeError: global.todos.findIdnex is not a function

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -68,7 +68,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: "Invalid todo ID" }, { status: 400 })
   }
 
-  const todoIndex = global.todos!.findIdnex((t) => t.id === idNum)
+  const todoIndex = global.todos!.findIndex((t) => t.id === idNum)
 
   if (todoIndex === -1) {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 })


### PR DESCRIPTION
## Error Description
The code is trying to use a method named 'findIdnex' on the 'global.todos' object, but this method does not exist. The likely cause is a typo: 'findIdnex' should probably be 'findIndex'. This occurred in the API route for todos.

## Technical Details
Trace ID: 3e058eb157d424b12b937c8487dd6df7

## Changes
This PR contains an automated fix for the production error identified in the telemetry data.

---
*Generated by Codex Runner Bot*