### PR TITLE
Fix: TypeError: global.todos.findIdnex is not a function

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -68,7 +68,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: "Invalid todo ID" }, { status: 400 })
   }
 
-  const todoIndex = global.todos!.findIdnex((t) => t.id === idNum)
+  const todoIndex = global.todos!.findIndex((t) => t.id === idNum)
 
   if (todoIndex === -1) {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 })


### PR DESCRIPTION
## Error Description
The 'findIdnex' method was called on the 'global.todos' object, but this method does not exist. Likely a typo; check for 'findIndex'.

## Technical Details
Trace ID: ee66143b89f6fb8fb412a3a7784c048b

## Changes
This PR contains an automated fix for the production error identified in the telemetry data.

---
*Generated by Codex Runner Bot*