### PR TITLE
Fix: TypeError: global.todos.findIdnex is not a function

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -68,7 +68,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: "Invalid todo ID" }, { status: 400 })
   }
 
-  const todoIndex = global.todos!.findIdnex((t) => t.id === idNum)
+  const todoIndex = global.todos!.findIndex((t) => t.id === idNum)
 
   if (todoIndex === -1) {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 })


### PR DESCRIPTION
## Error Description
The code attempted to call a method named 'findIdnex' on the global 'todos' object. This method does not exist. Likely a typo, as 'findIndex' is a standard JavaScript array method. Check the implementation of 'global.todos' and the usage of 'findIdnex' in '/var/task/app/api/todos/[id]/route.js'.

## Technical Details
Trace ID: a6404bf1e99073302973e8cded3c4c5b

## Changes
This PR contains an automated fix for the production error identified in the telemetry data.

---
*Generated by Codex Runner Bot*