### PR TITLE
Fix: TypeError: global.todos.findIdnex is not a function in /api/todos/[id]/route.js

### DIFF
--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -68,7 +68,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: "Invalid todo ID" }, { status: 400 })
   }
 
-  const todoIndex = global.todos!.findIdnex((t) => t.id === idNum)
+  const todoIndex = global.todos!.findIndex((t) => t.id === idNum)
 
   if (todoIndex === -1) {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 })


### PR DESCRIPTION
## Error Description
The code attempted to call `findIdnex` on the `global.todos` object, but this method does not exist. This is likely a typo and should be `findIndex`. The error occurred in the /api/todos/[id]/route.js file, within the `to.do` function.

## Technical Details
Trace ID: 30afab1a46ab2905dfb85b53b3bb6455

## Changes
This PR contains an automated fix for the production error identified in the telemetry data.

---
*Generated by Codex Runner Bot*